### PR TITLE
Fix RemovedInDjango19Warning (django.forms.util)

### DIFF
--- a/djangocms_inherit/forms.py
+++ b/djangocms_inherit/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.forms.models import ModelForm
-from django.forms.util import ErrorList
+from django.forms.utils import ErrorList
 from django.utils.translation import ugettext_lazy as _
 
 from cms.models import Page

--- a/djangocms_inherit/forms.py
+++ b/djangocms_inherit/forms.py
@@ -1,6 +1,10 @@
 from django import forms
 from django.forms.models import ModelForm
-from django.forms.utils import ErrorList
+try:
+    from django.forms.utils import ErrorList
+except ImportError:
+    # Django<1.7 (deprecated in Django 1.8, removed in 1.9)
+    from django.forms.util import ErrorList
 from django.utils.translation import ugettext_lazy as _
 
 from cms.models import Page

--- a/djangocms_inherit/forms.py
+++ b/djangocms_inherit/forms.py
@@ -15,17 +15,17 @@ from .models import InheritPagePlaceholder
 class InheritForm(ModelForm):
     from_page = forms.ModelChoiceField(
         label=_("page"), queryset=Page.objects.drafts(), required=False)
-    
+
     class Meta:
         model = InheritPagePlaceholder
         exclude = ('page', 'position', 'placeholder', 'language',
                    'plugin_type')
-    
-    def for_site(self, site):    
+
+    def for_site(self, site):
         # override the page_link fields queryset to containt just pages for
         # current site
         self.fields['from_page'].queryset = Page.objects.drafts().on_site(site)
-        
+
     def clean(self):
         cleaned_data = super(InheritForm, self).clean()
         if not cleaned_data['from_page'] and not cleaned_data['from_language']:


### PR DESCRIPTION
Does away with the `RemovedInDjango19Warning` advertised by Django 1.8. Also fixes a few white-space complaints by `flake8` in the module that had to change. Original complaint:
```
$ python manage.py runserver
/<myvirtualenv>/python2.7/site-packages/djangocms_inherit-0.1-py2.7.egg/djangocms_inherit/forms.py:3: RemovedInDjango19Warning: The django.forms.util module has been renamed. Use django.forms.utils instead.
  from django.forms.util import ErrorList
```

This change is backward compatible, also works with Django<1.7. Manually tested / verified with Django 1.5 through 1.8.