### PR TITLE
Green light go pagefield

### DIFF
--- a/djangocms_inherit/forms.py
+++ b/djangocms_inherit/forms.py
@@ -1,4 +1,5 @@
-from django import forms
+# -*- coding: utf-8 -*-
+
 from django.forms.models import ModelForm
 from django.forms.util import ErrorList
 from django.utils.translation import ugettext_lazy as _

--- a/djangocms_inherit/models.py
+++ b/djangocms_inherit/models.py
@@ -1,8 +1,10 @@
+# -*- coding: utf-8 -*-
+
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 from cms.utils.i18n import get_language_tuple
-from cms.models import CMSPlugin, Page
+from cms.models import CMSPlugin
 from cms.models.fields import PageField
 
 


### PR DESCRIPTION
Simply rebases and fixes merge errors for #11 from @jsma.

I tried to make a South migration using djangocms-helper, but it reported that no migration is required for South since the PageField is an FK anyway.