### PR TITLE
initial Django 2.0 support

### DIFF
--- a/djangocms_inherit/migrations/0001_initial.py
+++ b/djangocms_inherit/migrations/0001_initial.py
@@ -15,9 +15,9 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='InheritPagePlaceholder',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(serialize=False, parent_link=True, auto_created=True, to='cms.CMSPlugin', primary_key=True)),
+                ('cmsplugin_ptr', models.OneToOneField(serialize=False, parent_link=True, auto_created=True, to='cms.CMSPlugin', primary_key=True, on_delete=models.CASCADE)),
                 ('from_language', models.CharField(help_text='Optional: the language of the plugins you want', blank=True, max_length=5, choices=get_language_tuple(), verbose_name='language', null=True)),
-                ('from_page', models.ForeignKey(help_text='Choose a page to include its plugins into this placeholder, empty will choose current page', blank=True, to='cms.Page', null=True)),
+                ('from_page', models.ForeignKey(help_text='Choose a page to include its plugins into this placeholder, empty will choose current page', blank=True, to='cms.Page', null=True, on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,

--- a/djangocms_inherit/migrations/0003_auto_20160825_1821.py
+++ b/djangocms_inherit/migrations/0003_auto_20160825_1821.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='inheritpageplaceholder',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='djangocms_inherit_inheritpageplaceholder', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='djangocms_inherit_inheritpageplaceholder', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
     ]

--- a/djangocms_inherit/models.py
+++ b/djangocms_inherit/models.py
@@ -28,6 +28,7 @@ class InheritPagePlaceholder(CMSPlugin):
         to=CMSPlugin,
         parent_link=True,
         related_name='djangocms_inherit_inheritpageplaceholder',
+        on_delete=models.CASCADE,
     )
 
     def copy_relations(self, oldinstance):


### PR DESCRIPTION
Squashing some basic errors and addressing low-level changes between Django 1.11 and 2.0.  Probably needs pull request #31 as well to behave with Django 2.0 AND django-cms 3.5.

django-cms is not Django 2.0 ready yet, but I'm trying to get various plugins and dependencies compatible to make it easier for the whole ecosystem to work on 2.0.x eventually.